### PR TITLE
Nix cache URL check should ignore trailing slash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-subscriber-wasm",
+ "url",
  "uuid",
  "wasm-bindgen",
 ]
@@ -2824,6 +2825,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tower-http = { version = "0.4", features = ["full"], optional = true }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-subscriber-wasm = "0.1"
+url = { version = "2.4", features = ["serde"] }
 uuid = { version = "1.3.0", features = ["serde", "v4", "js"] }
 wasm-bindgen = "=0.2.87"                                                  # The version here must match the pinned stuff in Nix flakes.
 

--- a/src/nix/config.rs
+++ b/src/nix/config.rs
@@ -1,8 +1,11 @@
 //! Rust module for `nix show-config`
+use std::fmt::Display;
+
 use leptos::*;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "ssr")]
 use tracing::instrument;
+use url::Url;
 
 /// Nix configuration spit out by `nix show-config`
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -13,7 +16,7 @@ pub struct NixConfig {
     pub extra_platforms: ConfigVal<Vec<String>>,
     pub flake_registry: ConfigVal<String>,
     pub max_jobs: ConfigVal<i32>,
-    pub substituters: ConfigVal<Vec<String>>,
+    pub substituters: ConfigVal<Vec<Url>>,
     pub system: ConfigVal<String>,
 }
 
@@ -30,7 +33,10 @@ pub struct ConfigVal<T> {
 }
 
 /// The HTML view for config values that are lists; rendered as HTML lists.
-impl IntoView for ConfigVal<Vec<String>> {
+impl<T> IntoView for ConfigVal<Vec<T>>
+where
+    T: Display,
+{
     fn into_view(self, cx: Scope) -> View {
         view! { cx,
             // Render a list of T items in the list 'self'
@@ -38,7 +44,7 @@ impl IntoView for ConfigVal<Vec<String>> {
                 {self
                     .value
                     .into_iter()
-                    .map(|item| view! { cx, <li class="list-disc">{item}</li> })
+                    .map(|item| view! { cx, <li class="list-disc">{item.to_string()}</li> })
                     .collect_view(cx)}
             </div>
         }
@@ -77,7 +83,7 @@ pub async fn run_nix_show_config() -> Result<NixConfig, ServerFnError> {
 
 impl IntoView for NixConfig {
     fn into_view(self, cx: Scope) -> View {
-        fn mk_row<T: IntoView>(cx: Scope, key: impl IntoView, value: ConfigVal<T>) -> impl IntoView
+        fn mk_row<T>(cx: Scope, key: impl IntoView, value: ConfigVal<T>) -> impl IntoView
         where
             ConfigVal<T>: IntoView,
         {

--- a/src/nix/health/check/caches.rs
+++ b/src/nix/health/check/caches.rs
@@ -1,5 +1,6 @@
 use leptos::*;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::nix::{
     config::ConfigVal,
@@ -12,7 +13,7 @@ use crate::nix::{
 
 /// Check that [crate::nix::config::NixConfig::substituters] is set to a good value.
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Caches(ConfigVal<Vec<String>>);
+pub struct Caches(ConfigVal<Vec<Url>>);
 
 impl Check for Caches {
     fn check(info: &info::NixInfo) -> Self {
@@ -23,9 +24,9 @@ impl Check for Caches {
     }
     fn report(&self) -> Report<WithDetails> {
         let val = &self.0.value;
-        if val.contains(&"https://cache.nixos.org".to_string()) {
+        if val.contains(&Url::parse("https://cache.nixos.org").unwrap()) {
             // TODO: Hardcoding this to test failed reports
-            if val.contains(&"https://nammayatri.cachix.org".to_string()) {
+            if val.contains(&Url::parse("https://nammayatri.cachix.org").unwrap()) {
                 Report::Green
             } else {
                 Report::Red(WithDetails {

--- a/src/nix/health/check/caches.rs
+++ b/src/nix/health/check/caches.rs
@@ -23,9 +23,9 @@ impl Check for Caches {
     }
     fn report(&self) -> Report<WithDetails> {
         let val = &self.0.value;
-        if val.contains(&"https://cache.nixos.org/".to_string()) {
+        if val.contains(&"https://cache.nixos.org".to_string()) {
             // TODO: Hardcoding this to test failed reports
-            if val.contains(&"https://nammayatri.cachix.org/".to_string()) {
+            if val.contains(&"https://nammayatri.cachix.org".to_string()) {
                 Report::Green
             } else {
                 Report::Red(WithDetails {


### PR DESCRIPTION
substituters = https://cache.nixos.org https://nammayatri.cachix.org

The above config without trailing slash should be considered as correct.