### PR TITLE
Support for `--refresh`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::nix::{
 use crate::widget::*;
 use crate::{
     leptos_extra::{
-        query::{self, QueryInput, RefetchQueryButton},
+        query::{self, RefetchQueryButton},
         signal::{provide_signal, use_signal, SignalWithResult},
     },
     nix::command::Refresh,
@@ -132,7 +132,7 @@ fn NixFlake(cx: Scope) -> impl IntoView {
     view! { cx,
         <Title text="Nix Flake"/>
         <h1 class="text-5xl font-bold">{"Nix Flake"}</h1>
-        <QueryInput id="nix-flake-input" query=url suggestions/>
+        <TextInput id="nix-flake-input" label="Load a Nix Flake" val=url suggestions/>
         <RefetchQueryButton result query/>
         <Outlet/>
     }

--- a/src/leptos_extra/query.rs
+++ b/src/leptos_extra/query.rs
@@ -2,7 +2,7 @@
 use cfg_if::cfg_if;
 use leptos::*;
 use leptos_query::*;
-use std::{fmt::Display, future::Future, hash::Hash, str::FromStr};
+use std::{future::Future, hash::Hash};
 use tracing::instrument;
 
 /// The result type of Leptos [server] function returning a `T`
@@ -69,63 +69,6 @@ const LEPTOS_MODE: &str = {
         compile_error!("Either ssr or hydrate feature must be enabled");
     }}
 };
-
-/// Input element component to pass arguments to a [leptos_query] query
-///
-/// A label, input element, and datalist are rendered, as well as error div.
-/// [FromStr::from_str] is used to parse the input value into `K`.
-///
-/// Arguments:
-/// * `id`: The id of the input element
-/// * `suggestions`: The initial suggestions to show in the datalist
-/// * `query`: Input element value is initialized with this [ReadSignal]
-/// * `set_query`: Input element will set this [WriteSignal]
-#[component]
-pub fn QueryInput<K>(
-    cx: Scope,
-    id: &'static str,
-    /// Initial suggestions to show in the datalist
-    suggestions: Vec<K>,
-    query: RwSignal<K>,
-) -> impl IntoView
-where
-    K: ToString + FromStr + Hash + Eq + Clone + Display + 'static,
-    <K as std::str::FromStr>::Err: Display,
-{
-    let datalist_id = &format!("{}-datalist", id);
-    // Input query to the server fn
-    // Errors in input element (based on [FromStr::from_str])
-    let (input_err, set_input_err) = create_signal(cx, None::<String>);
-    view! { cx,
-        <label for=id>"Load a Nix flake"</label>
-        <input
-            list=datalist_id
-            id=id.to_string()
-            type="text"
-            class="w-full p-1 font-mono"
-            on:change=move |ev| {
-                match FromStr::from_str(&event_target_value(&ev)) {
-                    Ok(url) => {
-                        query.set(url);
-                        set_input_err(None)
-                    }
-                    Err(e) => set_input_err(Some(e.to_string())),
-                }
-            }
-
-            prop:value=move || query.get().to_string()
-        />
-        <span class="text-red-500">{input_err}</span>
-        // TODO: use local storage, and cache user's inputs
-        <datalist id=datalist_id>
-            {suggestions
-                .iter()
-                .map(|s| view! { cx, <option value=s.to_string()></option> })
-                .collect_view(cx)}
-
-        </datalist>
-    }
-}
 
 /// Button component to refresh the given [leptos_query] query.
 ///

--- a/src/leptos_extra/query.rs
+++ b/src/leptos_extra/query.rs
@@ -86,8 +86,7 @@ pub fn QueryInput<K>(
     id: &'static str,
     /// Initial suggestions to show in the datalist
     suggestions: Vec<K>,
-    query: ReadSignal<K>,
-    set_query: WriteSignal<K>,
+    query: RwSignal<K>,
 ) -> impl IntoView
 where
     K: ToString + FromStr + Hash + Eq + Clone + Display + 'static,
@@ -107,14 +106,14 @@ where
             on:change=move |ev| {
                 match FromStr::from_str(&event_target_value(&ev)) {
                     Ok(url) => {
-                        set_query(url);
+                        query.set(url);
                         set_input_err(None)
                     }
                     Err(e) => set_input_err(Some(e.to_string())),
                 }
             }
 
-            prop:value=move || query().to_string()
+            prop:value=move || query.get().to_string()
         />
         <span class="text-red-500">{input_err}</span>
         // TODO: use local storage, and cache user's inputs

--- a/src/leptos_extra/signal.rs
+++ b/src/leptos_extra/signal.rs
@@ -4,8 +4,8 @@ use tracing::instrument;
 
 /// [provide_context] a new signal of type `T` in the current scope
 pub fn provide_signal<T: 'static>(cx: Scope, default: T) {
-    let (get, set) = create_signal(cx, default);
-    provide_context(cx, (get, set));
+    let sig = create_rw_signal(cx, default);
+    provide_context(cx, sig);
 }
 
 /// [use_context] the signal of type `T` in the current scope
@@ -13,7 +13,7 @@ pub fn provide_signal<T: 'static>(cx: Scope, default: T) {
 /// If the signal was not provided in a top-level scope (via [provide_signal])
 /// this method will panic after tracing an error.
 #[instrument(name = "use_signal")]
-pub fn use_signal<T>(cx: Scope) -> (ReadSignal<T>, WriteSignal<T>) {
+pub fn use_signal<T>(cx: Scope) -> RwSignal<T> {
     use_context(cx)
         .ok_or_else(|| {
             // This happens if the dev forgets to call `provide_signal::<T>` in

--- a/src/nix/command.rs
+++ b/src/nix/command.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 /// options](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix#options)
 pub struct NixCmd {
     pub extra_experimental_features: Vec<String>,
+    pub refresh: bool,
 }
 
 impl Default for NixCmd {
@@ -15,6 +16,7 @@ impl Default for NixCmd {
     fn default() -> Self {
         Self {
             extra_experimental_features: vec!["nix-command".to_string(), "flakes".to_string()],
+            refresh: false,
         }
     }
 }
@@ -27,11 +29,16 @@ impl NixCmd {
         cmd
     }
 
+    /// Convert this [NixCmd] configuration into a list of arguments for
+    /// [Command]
     fn args(&self) -> Vec<String> {
         let mut args = vec![];
         if !self.extra_experimental_features.is_empty() {
             args.push("--extra-experimental-features".to_string());
             args.push(self.extra_experimental_features.join(" "));
+        }
+        if self.refresh {
+            args.push("--refresh".to_string());
         }
         args
     }

--- a/src/nix/command.rs
+++ b/src/nix/command.rs
@@ -1,0 +1,38 @@
+//! Nix command configuration
+
+use tokio::process::Command;
+
+/// The `nix` command along with its global options.
+///
+/// See [available global
+/// options](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix#options)
+pub struct NixCmd {
+    pub extra_experimental_features: Vec<String>,
+}
+
+impl Default for NixCmd {
+    /// The default `nix` command with flakes already enabled.
+    fn default() -> Self {
+        Self {
+            extra_experimental_features: vec!["nix-command".to_string(), "flakes".to_string()],
+        }
+    }
+}
+
+impl NixCmd {
+    /// Return a [Command] for this [NixCmd] configuration
+    pub fn command(&self) -> Command {
+        let mut cmd = Command::new("nix");
+        cmd.args(self.args());
+        cmd
+    }
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![];
+        if !self.extra_experimental_features.is_empty() {
+            args.push("--extra-experimental-features".to_string());
+            args.push(self.extra_experimental_features.join(" "));
+        }
+        args
+    }
+}

--- a/src/nix/config.rs
+++ b/src/nix/config.rs
@@ -76,14 +76,9 @@ impl IntoView for ConfigVal<System> {
 #[cfg(feature = "ssr")]
 #[instrument(name = "show-config")]
 pub async fn run_nix_show_config() -> Result<NixConfig, ServerFnError> {
-    use tokio::process::Command;
-    let mut cmd = Command::new("nix");
-    cmd.args(vec![
-        "--extra-experimental-features",
-        "nix-command",
-        "show-config",
-        "--json",
-    ]);
+    use crate::nix::command;
+    let mut cmd = command::NixCmd::default().command();
+    cmd.args(vec!["show-config", "--json"]);
     let stdout: Vec<u8> = crate::command::run_command(&mut cmd).await?;
     let v = serde_json::from_slice::<NixConfig>(&stdout)?;
     Ok(v)

--- a/src/nix/flake/mod.rs
+++ b/src/nix/flake/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use self::{outputs::FlakeOutputs, schema::FlakeSchema, system::System, url::FlakeUrl};
+use crate::nix::command::Refresh;
 
 /// All the information about a Nix flake
 // #[serde_as]
@@ -29,12 +30,13 @@ pub struct Flake {
 /// Get [Flake] info for the given flake url
 #[instrument(name = "flake")]
 #[server(GetFlake, "/api")]
-pub async fn get_flake(url: FlakeUrl) -> Result<Flake, ServerFnError> {
+pub async fn get_flake(args: (FlakeUrl, Refresh)) -> Result<Flake, ServerFnError> {
     use super::config::run_nix_show_config;
+    let (url, refresh) = args;
     // TODO: Can we cache this?
     let nix_config = run_nix_show_config().await?;
     let system = nix_config.system.value;
-    let output = self::show::run_nix_flake_show(&url).await?;
+    let output = self::show::run_nix_flake_show(&url, refresh).await?;
     Ok(Flake {
         url,
         output: output.clone(),

--- a/src/nix/flake/show.rs
+++ b/src/nix/flake/show.rs
@@ -1,17 +1,13 @@
 //! Rust module for `nix flake show`
 
-use super::outputs::FlakeOutputs;
-use super::url::FlakeUrl;
+use super::{outputs::FlakeOutputs, url::FlakeUrl};
+use crate::nix::command;
 use leptos::*;
 
 /// Run `nix flake show` on the given flake url
 pub async fn run_nix_flake_show(flake_url: &FlakeUrl) -> Result<FlakeOutputs, ServerFnError> {
-    use tokio::process::Command;
-
-    let mut cmd = Command::new("nix");
+    let mut cmd = command::NixCmd::default().command();
     cmd.args(vec![
-        "--extra-experimental-features",
-        "nix-command flakes",
         "flake",
         "show",
         "--legacy", // for showing nixpkgs legacyPackages

--- a/src/nix/flake/show.rs
+++ b/src/nix/flake/show.rs
@@ -1,12 +1,19 @@
 //! Rust module for `nix flake show`
 
 use super::{outputs::FlakeOutputs, url::FlakeUrl};
-use crate::nix::command;
+use crate::nix::command::{NixCmd, Refresh};
 use leptos::*;
 
 /// Run `nix flake show` on the given flake url
-pub async fn run_nix_flake_show(flake_url: &FlakeUrl) -> Result<FlakeOutputs, ServerFnError> {
-    let mut cmd = command::NixCmd::default().command();
+pub async fn run_nix_flake_show(
+    flake_url: &FlakeUrl,
+    refresh: Refresh,
+) -> Result<FlakeOutputs, ServerFnError> {
+    let mut cmd = NixCmd {
+        refresh,
+        ..NixCmd::default()
+    }
+    .command();
     cmd.args(vec![
         "flake",
         "show",
@@ -24,5 +31,5 @@ pub async fn run_nix_flake_show(flake_url: &FlakeUrl) -> Result<FlakeOutputs, Se
 #[ignore] // Requires network, so won't work in Nix
 async fn test_nix_flake_show() {
     let flake_url = "nixpkgs".into();
-    assert!(run_nix_flake_show(&flake_url).await.is_ok());
+    assert!(run_nix_flake_show(&flake_url, false.into()).await.is_ok());
 }

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -1,5 +1,4 @@
 //! Rust module to interact with Nix
-#[cfg(feature = "ssr")]
 pub mod command;
 pub mod config;
 pub mod flake;

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -1,4 +1,6 @@
 //! Rust module to interact with Nix
+#[cfg(feature = "ssr")]
+pub mod command;
 pub mod config;
 pub mod flake;
 pub mod health;

--- a/src/nix/version.rs
+++ b/src/nix/version.rs
@@ -51,8 +51,8 @@ impl FromStr for NixVersion {
 #[cfg(feature = "ssr")]
 #[instrument(name = "version")]
 pub async fn run_nix_version() -> Result<NixVersion, ServerFnError> {
-    use tokio::process::Command;
-    let mut cmd = Command::new("nix");
+    use crate::nix::command;
+    let mut cmd = command::NixCmd::default().command();
     cmd.arg("--version");
     let stdout: Vec<u8> = crate::command::run_command(&mut cmd).await?;
     // Utf-8 errors don't matter here because we're just parsing numbers


### PR DESCRIPTION
Backend/frontend for `nix --refresh` is implemented, but we don't have frontend UI for toggling it yet. Leaving it disabled by default.
