### PR TITLE
Add CLI for nix-health

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,7 +1871,9 @@ dependencies = [
 name = "nix_health"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
+ "human-panic",
  "nix_rs",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,6 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tokio",
- "tracing",
- "tracing-subscriber",
- "tracing-subscriber-wasm",
  "url",
 ]
 
@@ -1949,8 +1946,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
- "tracing-subscriber-wasm",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "common_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +823,27 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "flate2"
@@ -1414,6 +1446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1922,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cfg-if",
+ "colored",
  "human-panic",
  "nix_rs",
  "regex",
@@ -2431,6 +2481,19 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ default-members = [".", "crates/*"]
 [workspace.package]
 edition = "2021"
 license = "AGPL-3.0-only"
+repository = "https://github.com/juspay/nix-browser"
 
 [workspace.dependencies]
 cfg-if = "1"
+human-panic = "1.1.5"
 leptos = { version = "0.4", features = ["serde", "nightly"] }
 leptos_meta = { version = "0.4", features = ["nightly"] }
 leptos_router = { version = "0.4", features = ["nightly"] }
@@ -43,8 +45,8 @@ clap = { version = "4.3", features = ["derive", "env"] }
 console_error_panic_hook = "0.1"
 console_log = { version = "1" }
 http = { version = "0.2", optional = true }
-human-panic = "1.1.5"
 hyper = { version = "0.14", features = ["server"], optional = true }
+human-panic.workspace = true
 leptos.workspace = true
 leptos_axum = { version = "0.4", optional = true }
 leptos_meta.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ clap = { version = "4.3", features = ["derive", "env"] }
 console_error_panic_hook = "0.1"
 console_log = { version = "1" }
 http = { version = "0.2", optional = true }
-hyper = { version = "0.14", features = ["server"], optional = true }
 human-panic.workspace = true
+hyper = { version = "0.14", features = ["server"], optional = true }
 leptos.workspace = true
 leptos_axum = { version = "0.4", optional = true }
 leptos_meta.workspace = true

--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ We publish the following crates from this repo:
 | Crate Link | Description | 
 |------------|-------------|
 | https://crates.io/crates/nix_rs | Rust interface to the Nix command line |
+| https://crates.io/crates/nix_health | Nix health check library and executable |

--- a/crates/nix_health/Cargo.toml
+++ b/crates/nix_health/Cargo.toml
@@ -21,9 +21,6 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 tokio = { version = "1.29", features = ["full"], optional = true }
-tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-subscriber-wasm.workspace = true
 url = { version = "2.4", features = ["serde"] }
 nix_rs.workspace = true
 human-panic.workspace = true

--- a/crates/nix_health/Cargo.toml
+++ b/crates/nix_health/Cargo.toml
@@ -6,6 +6,11 @@ version = "0.1.0"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "nix-health"
+path = "src/main.rs"
+required-features = ["ssr"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,6 +26,8 @@ tracing-subscriber.workspace = true
 tracing-subscriber-wasm.workspace = true
 url = { version = "2.4", features = ["serde"] }
 nix_rs.workspace = true
+human-panic.workspace = true
+anyhow = { version = "1.0.75", optional = true }
 
 [features]
-ssr = ["dep:tokio", "nix_rs/ssr"]
+ssr = ["dep:tokio", "dep:anyhow", "nix_rs/ssr"]

--- a/crates/nix_health/Cargo.toml
+++ b/crates/nix_health/Cargo.toml
@@ -28,6 +28,7 @@ url = { version = "2.4", features = ["serde"] }
 nix_rs.workspace = true
 human-panic.workspace = true
 anyhow = { version = "1.0.75", optional = true }
+colored = { version = "2.0", optional = true }
 
 [features]
-ssr = ["dep:tokio", "dep:anyhow", "nix_rs/ssr"]
+ssr = ["dep:tokio", "dep:anyhow", "dep:colored", "nix_rs/ssr"]

--- a/crates/nix_health/src/check/caches.rs
+++ b/crates/nix_health/src/check/caches.rs
@@ -18,16 +18,30 @@ impl Check for Caches {
     fn name(&self) -> &'static str {
         "Nix Caches in use"
     }
+    fn information(&self) -> String {
+        format!(
+            "substituters = {}",
+            self.0
+                .value
+                .iter()
+                .map(|url| url.to_string())
+                .collect::<Vec<String>>()
+                .join(" ")
+        )
+    }
     fn report(&self) -> Report<WithDetails> {
         let val = &self.0.value;
+        // TODO: Hardcoding this to test failed reports
+        // TODO: Make this customizable in a flake
+        let required_cache = Url::parse("https://nix-community.cachix.org").unwrap();
         if val.contains(&Url::parse("https://cache.nixos.org").unwrap()) {
-            // TODO: Hardcoding this to test failed reports
-            if val.contains(&Url::parse("https://nammayatri.cachix.org").unwrap()) {
+            if val.contains(&required_cache) {
                 Report::Green
             } else {
                 Report::Red(WithDetails {
-                    msg: "You are missing the nammayatri cache".into(),
-                    suggestion: "Run 'nix run nixpkgs#cachix use nammayatri".into(),
+                    msg: format!("You are missing a required cache: {}", required_cache),
+                    // TODO: Suggestion should be smart. Use 'cachix use' if a cachix cache.
+                    suggestion: "Add substituters in /etc/nix/nix.conf or use 'cachix use'".into(),
                 })
             }
         } else {

--- a/crates/nix_health/src/check/caches.rs
+++ b/crates/nix_health/src/check/caches.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use nix_rs::{config::ConfigVal, info};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -17,17 +19,6 @@ impl Check for Caches {
     }
     fn name(&self) -> &'static str {
         "Nix Caches in use"
-    }
-    fn information(&self) -> String {
-        format!(
-            "substituters = {}",
-            self.0
-                .value
-                .iter()
-                .map(|url| url.to_string())
-                .collect::<Vec<String>>()
-                .join(" ")
-        )
     }
     fn report(&self) -> Report<WithDetails> {
         let val = &self.0.value;
@@ -50,5 +41,20 @@ impl Check for Caches {
                 suggestion: "Try looking in /etc/nix/nix.conf".into(),
             })
         }
+    }
+}
+
+impl Display for Caches {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "substituters = {}",
+            self.0
+                .value
+                .iter()
+                .map(|url| url.to_string())
+                .collect::<Vec<String>>()
+                .join(" ")
+        )
     }
 }

--- a/crates/nix_health/src/check/flake_enabled.rs
+++ b/crates/nix_health/src/check/flake_enabled.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use nix_rs::{config::ConfigVal, info};
 use serde::{Deserialize, Serialize};
 
@@ -17,9 +19,6 @@ impl Check for FlakeEnabled {
     fn name(&self) -> &'static str {
         "Flakes Enabled"
     }
-    fn information(&self) -> String {
-        format!("experimental-features = {}", self.0.value.join(" "))
-    }
     fn report(&self) -> Report<WithDetails> {
         let val = &self.0.value;
         if val.contains(&"flakes".to_string()) && val.contains(&"nix-command".to_string()) {
@@ -30,5 +29,11 @@ impl Check for FlakeEnabled {
                 suggestion: "See https://nixos.wiki/wiki/Flakes#Enable_flakes".into(),
             })
         }
+    }
+}
+
+impl Display for FlakeEnabled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "experimental-features = {}", self.0.value.join(" "))
     }
 }

--- a/crates/nix_health/src/check/flake_enabled.rs
+++ b/crates/nix_health/src/check/flake_enabled.rs
@@ -17,6 +17,9 @@ impl Check for FlakeEnabled {
     fn name(&self) -> &'static str {
         "Flakes Enabled"
     }
+    fn information(&self) -> String {
+        format!("experimental-features = {}", self.0.value.join(" "))
+    }
     fn report(&self) -> Report<WithDetails> {
         let val = &self.0.value;
         if val.contains(&"flakes".to_string()) && val.contains(&"nix-command".to_string()) {

--- a/crates/nix_health/src/check/max_jobs.rs
+++ b/crates/nix_health/src/check/max_jobs.rs
@@ -17,6 +17,9 @@ impl Check for MaxJobs {
     fn name(&self) -> &'static str {
         "Max Jobs"
     }
+    fn information(&self) -> String {
+        format!("max-jobs = {}", self.0.value)
+    }
     fn report(&self) -> Report<WithDetails> {
         if self.0.value > 1 {
             Report::Green

--- a/crates/nix_health/src/check/max_jobs.rs
+++ b/crates/nix_health/src/check/max_jobs.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use nix_rs::{config::ConfigVal, info};
 use serde::{Deserialize, Serialize};
 
@@ -17,9 +19,6 @@ impl Check for MaxJobs {
     fn name(&self) -> &'static str {
         "Max Jobs"
     }
-    fn information(&self) -> String {
-        format!("max-jobs = {}", self.0.value)
-    }
     fn report(&self) -> Report<WithDetails> {
         if self.0.value > 1 {
             Report::Green
@@ -29,5 +28,11 @@ impl Check for MaxJobs {
                 suggestion: "Try editing /etc/nix/nix.conf".into(),
             })
         }
+    }
+}
+
+impl Display for MaxJobs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "max-jobs = {}", self.0.value)
     }
 }

--- a/crates/nix_health/src/check/min_nix_version.rs
+++ b/crates/nix_health/src/check/min_nix_version.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use nix_rs::{info, version::NixVersion};
 use serde::{Deserialize, Serialize};
 
@@ -17,9 +19,6 @@ impl Check for MinNixVersion {
     fn name(&self) -> &'static str {
         "Minimum Nix Version"
     }
-    fn information(&self) -> String {
-        format!("nix version = {}", self.0)
-    }
     fn report(&self) -> Report<WithDetails> {
         let min_required = NixVersion {
             major: 2,
@@ -34,5 +33,11 @@ impl Check for MinNixVersion {
                 suggestion: "See https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-upgrade-nix.html".into(),
             })
         }
+    }
+}
+
+impl Display for MinNixVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "nix version = {}", self.0)
     }
 }

--- a/crates/nix_health/src/check/min_nix_version.rs
+++ b/crates/nix_health/src/check/min_nix_version.rs
@@ -17,6 +17,9 @@ impl Check for MinNixVersion {
     fn name(&self) -> &'static str {
         "Minimum Nix Version"
     }
+    fn information(&self) -> String {
+        format!("nix version = {}", self.0)
+    }
     fn report(&self) -> Report<WithDetails> {
         let min_required = NixVersion {
             major: 2,

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -5,6 +5,8 @@ pub mod check;
 pub mod report;
 pub mod traits;
 
+use std::fmt::Display;
+
 use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
@@ -58,14 +60,17 @@ impl Check for NixHealth {
     fn name(&self) -> &'static str {
         "Nix Health"
     }
-    fn information(&self) -> String {
-        "".into()
-    }
     fn report(&self) -> Report<NoDetails> {
         if self.into_iter().all(|c| c.report() == Report::Green) {
             Report::Green
         } else {
             Report::Red(NoDetails)
         }
+    }
+}
+
+impl Display for NixHealth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "")
     }
 }

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -58,6 +58,9 @@ impl Check for NixHealth {
     fn name(&self) -> &'static str {
         "Nix Health"
     }
+    fn information(&self) -> String {
+        "".into()
+    }
     fn report(&self) -> Report<NoDetails> {
         if self.into_iter().all(|c| c.report() == Report::Green) {
             Report::Green

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -16,11 +16,11 @@ async fn main() -> anyhow::Result<()> {
         match report {
             Report::Green => {
                 println!("{}", format!("✅ {}", check.name()).green().bold());
-                println!("   {}", check.information().blue());
+                println!("   {}", check.to_string().blue());
             }
             Report::Red(details) => {
                 println!("{}", format!("❌ {}", check.name()).red().bold());
-                println!("   {}", check.information().blue());
+                println!("   {}", check.to_string().blue());
                 println!("   {}", details.msg.yellow());
                 println!("   {}", details.suggestion);
             }

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -10,18 +10,28 @@ async fn main() -> anyhow::Result<()> {
         .await
         .with_context(|| "Unable to gather nix info")?;
     let health = NixHealth::check(&info);
+    println!("Checking the health of your Nix setup:\n");
     for check in &health {
         let report = check.report();
         match report {
             Report::Green => {
                 println!("{}", format!("✅ {}", check.name()).green().bold());
+                println!("   {}", check.information().blue());
             }
             Report::Red(details) => {
                 println!("{}", format!("❌ {}", check.name()).red().bold());
+                println!("   {}", check.information().blue());
                 println!("   {}", details.msg.yellow());
                 println!("   {}", details.suggestion);
             }
         }
+        println!("");
     }
-    Ok(())
+    if health.into_iter().any(|c| c.report().is_red()) {
+        println!("{}", "!! Some checks failed (see above)".red().bold());
+        std::process::exit(1);
+    } else {
+        println!("{}", "✅ All checks passed".green().bold());
+        Ok(())
+    }
 }

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -1,13 +1,27 @@
-use nix_health::{traits::Check, NixHealth};
+use anyhow::Context;
+use colored::Colorize;
+use nix_health::{report::Report, traits::Check, NixHealth};
 use nix_rs::{command::NixCmd, info::NixInfo};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     human_panic::setup_panic!();
-    let info = NixInfo::from_nix(&NixCmd::default()).await?;
+    let info = NixInfo::from_nix(&NixCmd::default())
+        .await
+        .with_context(|| "Unable to gather nix info")?;
     let health = NixHealth::check(&info);
     for check in &health {
-        println!("{}: {:?}", check.name(), check.report());
+        let report = check.report();
+        match report {
+            Report::Green => {
+                println!("{}", format!("✅ {}", check.name()).green().bold());
+            }
+            Report::Red(details) => {
+                println!("{}", format!("❌ {}", check.name()).red().bold());
+                println!("   {}", details.msg.yellow());
+                println!("   {}", details.suggestion);
+            }
+        }
     }
     Ok(())
 }

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -1,0 +1,13 @@
+use nix_health::{traits::Check, NixHealth};
+use nix_rs::{command::NixCmd, info::NixInfo};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    human_panic::setup_panic!();
+    let info = NixInfo::from_nix(&NixCmd::default()).await?;
+    let health = NixHealth::check(&info);
+    for check in &health {
+        println!("{}: {:?}", check.name(), check.report());
+    }
+    Ok(())
+}

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
                 println!("   {}", details.suggestion);
             }
         }
-        println!("");
+        println!();
     }
     if health.into_iter().any(|c| c.report().is_red()) {
         println!("{}", "!! Some checks failed (see above)".red().bold());

--- a/crates/nix_health/src/report.rs
+++ b/crates/nix_health/src/report.rs
@@ -16,6 +16,19 @@ pub enum Report<T> {
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Clone)]
 pub struct NoDetails;
 
+impl<R> Report<R> {
+    pub fn is_green(&self) -> bool {
+        match self {
+            Report::Green => true,
+            Report::Red(_) => false,
+        }
+    }
+
+    pub fn is_red(&self) -> bool {
+        !self.is_green()
+    }
+}
+
 /// Details regarding a failed report
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Serialize, Deserialize, Clone)]
 pub struct WithDetails {

--- a/crates/nix_health/src/traits.rs
+++ b/crates/nix_health/src/traits.rs
@@ -4,6 +4,9 @@ use crate::report::{Report, WithDetails};
 use nix_rs::info;
 
 /// Types that implement health check with reports
+///
+/// The `Display` instance is expected to display the information
+/// (human-readable, in the CLI) used for doing the check.
 pub trait Check: Display {
     /// The type of the report produced by this health check
     type Report = Report<WithDetails>;

--- a/crates/nix_health/src/traits.rs
+++ b/crates/nix_health/src/traits.rs
@@ -14,6 +14,11 @@ pub trait Check {
     /// User-facing name for this health check
     fn name(&self) -> &'static str;
 
+    /// Information about this health check detected on the current environment.
+    ///
+    /// Useful to print in CLI.
+    fn information(&self) -> String;
+
     /// Return the health report for this health check
     fn report(&self) -> Self::Report;
 }

--- a/crates/nix_health/src/traits.rs
+++ b/crates/nix_health/src/traits.rs
@@ -1,8 +1,10 @@
+use std::fmt::Display;
+
 use crate::report::{Report, WithDetails};
 use nix_rs::info;
 
 /// Types that implement health check with reports
-pub trait Check {
+pub trait Check: Display {
     /// The type of the report produced by this health check
     type Report = Report<WithDetails>;
 
@@ -13,11 +15,6 @@ pub trait Check {
 
     /// User-facing name for this health check
     fn name(&self) -> &'static str;
-
-    /// Information about this health check detected on the current environment.
-    ///
-    /// Useful to print in CLI.
-    fn information(&self) -> String;
 
     /// Return the health report for this health check
     fn report(&self) -> Self::Report;

--- a/crates/nix_rs/Cargo.toml
+++ b/crates/nix_rs/Cargo.toml
@@ -20,8 +20,6 @@ serde_json.workspace = true
 serde_with.workspace = true
 tokio = { version = "1.29", features = ["full"], optional = true }
 tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-subscriber-wasm.workspace = true
 url = { version = "2.4", features = ["serde"] }
 
 [features]

--- a/crates/nix_rs/Cargo.toml
+++ b/crates/nix_rs/Cargo.toml
@@ -3,6 +3,7 @@ edition.workspace = true
 name = "nix_rs"
 version = "0.1.2"
 license.workspace = true
+repository.workspace = true
 description = "Rust library for interacting with the Nix command"
 
 [lib]

--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
     "leptos-fullstack": {
       "flake": false,
       "locked": {
-        "lastModified": 1692909627,
-        "narHash": "sha256-hJVU7JaMqprldE+1FjHtADe0Mumv+6c+1HfcvzCZJlg=",
+        "lastModified": 1694027158,
+        "narHash": "sha256-XzDBUA5jzTFDiLJtgvknAb9MuXwEGXmAd/ZoTqVUg+o=",
         "owner": "srid",
         "repo": "leptos-fullstack",
-        "rev": "321505b623d1a5b86cad9e5f39965c5084ba2c6c",
+        "rev": "4203055c17476616bec375cd7e471e91f70d26d0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -80,9 +80,15 @@
 
         packages = {
           default = self'.packages.nix-browser;
+          # FIXME: Unfortunately this builds all dependencies of the workspace.
+          # Can we avoid that?
           nix-health = config.leptos-fullstack.craneLib.buildPackage {
             inherit (config.leptos-fullstack) src;
             pname = "nix-health";
+            cargoExtraArgs = "--features ssr";
+            nativeBuildInputs = [
+              pkgs.nix # cargo tests need nix
+            ];
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,13 @@
             meta.description = "WIP: nix-browser";
           };
 
-        packages.default = self'.packages.nix-browser;
+        packages = {
+          default = self'.packages.nix-browser;
+          nix-health = config.leptos-fullstack.craneLib.buildPackage {
+            inherit (config.leptos-fullstack) src;
+            pname = "nix-health";
+          };
+        };
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [

--- a/flake.nix
+++ b/flake.nix
@@ -80,15 +80,16 @@
 
         packages = {
           default = self'.packages.nix-browser;
-          # FIXME: Unfortunately this builds all dependencies of the workspace.
-          # Can we avoid that?
           nix-health = config.leptos-fullstack.craneLib.buildPackage {
             inherit (config.leptos-fullstack) src;
             pname = "nix-health";
-            cargoExtraArgs = "--features ssr";
             nativeBuildInputs = [
               pkgs.nix # cargo tests need nix
             ];
+            cargoExtraArgs = "-p nix_health --features ssr";
+            # Disable tests on macOS for https://github.com/garnix-io/issues/issues/69
+            # If/when we move to Jenkins, this won't be necessary.
+            doCheck = !pkgs.stdenv.isDarwin;
           };
         };
 

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ watch $RUST_BACKTRACE="1":
 
 alias w := watch
 
+# Run 'cargo run' for nix-health CLI in watch mode
+watch-nix-health:
+    cargo watch -- cargo run --bin nix-health --features=ssr
+
 # Run tests (backend & frontend)
 test:
     cargo test


### PR DESCRIPTION
The idea is to eventually supplant https://github.com/srid/nix-health

- [x] Full console reporting
- [x] `nix run` invocation
- [ ] publish crate