### PR TITLE
ci/github: Run `nix build` separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,5 +13,9 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: yaxitech/nix-install-pkgs-action@v3
+        with:
+          packages: "nixpkgs#nixci"
+      - run: nixci
       - name: E2E tests
         run: nix run .#e2e-playwright-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: yaxitech/nix-install-pkgs-action@v3
-        with:
-          packages: "nixpkgs#nixci"
-      - run: nixci
+      - run: nix build --no-link --print-out-paths
       - name: E2E tests
         run: nix run .#e2e-playwright-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build --no-link --print-out-paths
+      - run: nix build --no-link --print-out-paths .#e2e-playwright-test
       - name: E2E tests
         run: nix run .#e2e-playwright-test


### PR DESCRIPTION
So we can time e2e tests separately.