### PR TITLE
`nix-health` - Accept config from `flake.nix`

### DIFF
--- a/crates/nix_health/src/check/caches.rs
+++ b/crates/nix_health/src/check/caches.rs
@@ -23,8 +23,6 @@ impl Default for Caches {
 fn default_caches() -> Vec<Url> {
     vec![
         Url::parse("https://cache.nixos.org").unwrap(),
-        // TODO: Hardcoding this for now, so as to test failed reports
-        Url::parse("https://nix-community.cachix.org").unwrap(),
     ]
 }
 

--- a/crates/nix_health/src/check/caches.rs
+++ b/crates/nix_health/src/check/caches.rs
@@ -21,9 +21,7 @@ impl Default for Caches {
 }
 
 fn default_caches() -> Vec<Url> {
-    vec![
-        Url::parse("https://cache.nixos.org").unwrap(),
-    ]
+    vec![Url::parse("https://cache.nixos.org").unwrap()]
 }
 
 impl Checkable for Caches {

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -52,7 +52,7 @@ impl<'a> IntoIterator for &'a NixHealth {
 impl NixHealth {
     /// Create [NixHealth] using configuration from the given flake
     ///
-    /// Fallback to using th default health check config if the flake doesn't
+    /// Fallback to using the default health check config if the flake doesn't
     /// override it.
     #[cfg(feature = "ssr")]
     pub async fn from_flake(

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -27,7 +27,7 @@ pub struct NixHealth {
     #[serde(default)]
     pub flake_enabled: FlakeEnabled,
     #[serde(default)]
-    pub min_nix_version: MinNixVersion,
+    pub nix_version: MinNixVersion,
     #[serde(default)]
     pub trusted_users: TrustedUsers,
 }
@@ -39,7 +39,7 @@ impl<'a> IntoIterator for &'a NixHealth {
     /// Return an iterator to iterate on the fields of [NixHealth]
     fn into_iter(self) -> Self::IntoIter {
         let items: Vec<Self::Item> = vec![
-            &self.min_nix_version,
+            &self.nix_version,
             &self.flake_enabled,
             &self.max_jobs,
             &self.caches,
@@ -78,7 +78,7 @@ mod tests {
     fn test_json_deserialize_empty() {
         let json = r#"{}"#;
         let v: super::NixHealth = serde_json::from_str(json).unwrap();
-        assert_eq!(v.min_nix_version, MinNixVersion::default());
+        assert_eq!(v.nix_version, MinNixVersion::default());
         assert_eq!(v.caches, Caches::default());
         println!("{:?}", v);
     }
@@ -87,7 +87,7 @@ mod tests {
     fn test_json_deserialize_some() {
         let json = r#"{ "min-nix-version": { "min-required": "2.17.0" } }"#;
         let v: super::NixHealth = serde_json::from_str(json).unwrap();
-        assert_eq!(v.min_nix_version.min_required.to_string(), "2.17.0");
+        assert_eq!(v.nix_version.min_required.to_string(), "2.17.0");
         assert_eq!(v.caches, Caches::default());
     }
 }

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_json_deserialize_some() {
-        let json = r#"{ "min-nix-version": { "min-required": "2.17.0" } }"#;
+        let json = r#"{ "nix-version": { "min-required": "2.17.0" } }"#;
         let v: super::NixHealth = serde_json::from_str(json).unwrap();
         assert_eq!(v.nix_version.min_required.to_string(), "2.17.0");
         assert_eq!(v.caches, Caches::default());

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -12,7 +12,6 @@ use nix_rs::{command::NixCmd, env::NixEnv, info::NixInfo};
 async fn main() -> anyhow::Result<()> {
     human_panic::setup_panic!();
     let checks = run_checks().await?;
-    println!("Checking the health of your Nix setup:\n");
     for check in &checks {
         match &check.result {
             CheckResult::Green => {
@@ -50,8 +49,14 @@ async fn run_checks() -> anyhow::Result<Vec<Check>> {
         .await
         .with_context(|| "Unable to gather system info")?;
     let health: NixHealth = if Path::new("flake.nix").exists() {
-        NixHealth::from_flake(".#nix-health.default".into()).await
+        let flake_cfg = ".#nix-health.default".into();
+        println!(
+            "🩺️ Checking the health of your Nix setup, using config from local flake ({}):\n",
+            flake_cfg
+        );
+        NixHealth::from_flake(flake_cfg).await
     } else {
+        println!("🩺️️ Checking the health of your Nix setup:\n");
         Ok(NixHealth::default())
     }?;
     let checks = health.run_checks(&nix_info, &nix_env);

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Context;
 use colored::Colorize;
 use nix_health::{traits::CheckResult, NixHealth};
-use nix_rs::{command::NixCmd, env::NixEnv, info::NixInfo, flake::eval::nix_eval_attr_json};
+use nix_rs::{command::NixCmd, env::NixEnv, flake::eval::nix_eval_attr_json, info::NixInfo};
 use serde::de::DeserializeOwned;
 
 #[tokio::main]
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
     let nix_env = NixEnv::detect()
         .await
         .with_context(|| "Unable to gather system info")?;
-    let health : NixHealth = get_config().await?;
+    let health: NixHealth = get_config().await?;
     let checks = &health.run_checks(&nix_info, &nix_env);
     println!("Checking the health of your Nix setup:\n");
     for check in checks {
@@ -45,7 +45,10 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-async fn get_config<T>() -> anyhow::Result<T> where T: Default + DeserializeOwned {
+async fn get_config<T>() -> anyhow::Result<T>
+where
+    T: Default + DeserializeOwned,
+{
     if Path::new("flake.nix").exists() {
         let v = nix_eval_attr_json(".#nix-health.default".into()).await?;
         Ok(v)

--- a/crates/nix_rs/src/flake/eval.rs
+++ b/crates/nix_rs/src/flake/eval.rs
@@ -1,7 +1,6 @@
-use crate::command::{NixCmdError, NixCmd, CommandError};
+use crate::command::{CommandError, NixCmd, NixCmdError};
 
 use super::url::FlakeUrl;
-
 
 /// Run `nix eval <url> --json` and parse its JSON
 ///

--- a/crates/nix_rs/src/flake/eval.rs
+++ b/crates/nix_rs/src/flake/eval.rs
@@ -1,0 +1,36 @@
+use crate::command::{NixCmdError, NixCmd, CommandError};
+
+use super::url::FlakeUrl;
+
+
+/// Run `nix eval <url> --json` and parse its JSON
+///
+/// If the flake does not output the given attribute, use the `Default`
+/// implementation of `T`.
+pub async fn nix_eval_attr_json<T>(url: FlakeUrl) -> Result<T, NixCmdError>
+where
+    T: Default + serde::de::DeserializeOwned,
+{
+    let nix = NixCmd::default();
+    let result = nix
+        .run_with_args_expecting_json(&["eval", url.0.as_str(), "--json"])
+        .await;
+    match result {
+        Ok(v) => Ok(v),
+        Err(err) if error_is_missing_attribute(&err) => {
+            // The 'nixci' flake output attr is missing. User wants the default config.
+            Ok(T::default())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Check that [NixCmdError] is a missing attribute error
+fn error_is_missing_attribute(err: &NixCmdError) -> bool {
+    match err {
+        NixCmdError::CmdError(CommandError::ProcessFailed { stderr, .. }) => {
+            stderr.contains("does not provide attribute")
+        }
+        _ => false,
+    }
+}

--- a/crates/nix_rs/src/flake/eval.rs
+++ b/crates/nix_rs/src/flake/eval.rs
@@ -4,8 +4,8 @@ use super::url::FlakeUrl;
 
 /// Run `nix eval <url> --json` and parse its JSON
 ///
-/// If the flake does not output the given attribute, use the `Default`
-/// implementation of `T`.
+/// If the flake does not output the given attribute, return the [Default]
+/// value of `T`.
 pub async fn nix_eval_attr_json<T>(url: FlakeUrl) -> Result<T, NixCmdError>
 where
     T: Default + serde::de::DeserializeOwned,
@@ -15,12 +15,11 @@ where
         .run_with_args_expecting_json(&["eval", url.0.as_str(), "--json"])
         .await;
     match result {
-        Ok(v) => Ok(v),
         Err(err) if error_is_missing_attribute(&err) => {
             // The 'nixci' flake output attr is missing. User wants the default config.
             Ok(T::default())
         }
-        Err(err) => Err(err),
+        r => r,
     }
 }
 

--- a/crates/nix_rs/src/flake/mod.rs
+++ b/crates/nix_rs/src/flake/mod.rs
@@ -1,9 +1,9 @@
 //! Rust module for Nix flakes
+pub mod eval;
 pub mod outputs;
 pub mod schema;
 pub mod system;
 pub mod url;
-pub mod eval;
 
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "ssr")]

--- a/crates/nix_rs/src/flake/mod.rs
+++ b/crates/nix_rs/src/flake/mod.rs
@@ -1,4 +1,5 @@
 //! Rust module for Nix flakes
+#[cfg(feature = "ssr")]
 pub mod eval;
 pub mod outputs;
 pub mod schema;

--- a/crates/nix_rs/src/flake/mod.rs
+++ b/crates/nix_rs/src/flake/mod.rs
@@ -3,6 +3,7 @@ pub mod outputs;
 pub mod schema;
 pub mod system;
 pub mod url;
+pub mod eval;
 
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "ssr")]

--- a/crates/nix_rs/src/flake/url.rs
+++ b/crates/nix_rs/src/flake/url.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// Use `FromStr` to parse a string into a `FlakeUrl`. Or `From` or `Into` if
 /// you know the URL is valid.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct FlakeUrl(String);
+pub struct FlakeUrl(pub String);
 
 impl FlakeUrl {
     /// Provide real-world examples of flake URLs

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
       ];
       flake = {
         nix-health.default = {
-          min-nix-version.min-required = "2.18.0";
+          nix-version.min-required = "2.16.0";
           caches.required = [ "https://cache.garnix.io" ];
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,12 @@
         (inputs.leptos-fullstack + /nix/flake-module.nix)
         ./e2e/flake-module.nix
       ];
+      flake = {
+        nix-health.default = {
+          min-nix-version.min-required = "2.18.0";
+          caches.required = [ "https://cache.garnix.io" ];
+        };
+      };
       perSystem = { config, self', pkgs, lib, system, ... }: {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;

--- a/src/app/health.rs
+++ b/src/app/health.rs
@@ -93,7 +93,7 @@ pub async fn get_nix_health(_unit: ()) -> Result<Vec<nix_health::traits::Check>,
     use nix_rs::{env, info};
     let nix_info = info::NixInfo::from_nix(&nix_rs::command::NixCmd::default()).await?;
     let nix_env = env::NixEnv::detect().await?;
-    let health = NixHealth::new(None);
+    let health = NixHealth::default();
     let checks = health.run_checks(&nix_info, &nix_env);
     Ok(checks)
 }


### PR DESCRIPTION
#60 

At the moment, only the CLI executable uses this (looking at current directory flake), not the web UI.