### PR TITLE
gh-actions: Run after garnix finishes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: "CI"
 on:
-  workflow_run:
-    workflows: ["Garnix CI"]
+  check_run:
+    checks: ["Garnix CI"]
     types:
       - completed
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,7 @@
 name: "CI"
 on:
-  check_run:
-    checks: ["Garnix CI"]
-    types:
-      - completed
+  repository_dispatch:
+    types: [garnix-ci-success]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,9 @@
 name: "CI"
 on:
-  # Run only when pushing to master branch, and making PRs
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_run:
+    workflows: ["Garnix CI"]
+    types:
+      - completed
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Along with #68 this seeks to make e2e CI in github faster.

- [ ] make it work