### PR TITLE
Simplify and consolidate `NixEnv` & `NixInfo` types

### DIFF
--- a/crates/nix_health/src/check/caches.rs
+++ b/crates/nix_health/src/check/caches.rs
@@ -1,4 +1,4 @@
-use nix_rs::{env, info};
+use nix_rs::info;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -24,7 +24,6 @@ impl Checkable for Caches {
     fn check(
         &self,
         nix_info: &info::NixInfo,
-        nix_env: &env::NixEnv,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let val = &nix_info.nix_config.substituters.value;
@@ -47,7 +46,7 @@ impl Checkable for Caches {
                 ),
                 suggestion: format!(
                     "Caches can be added in your {} (see https://nixos.wiki/wiki/Binary_Cache#Using_a_binary_cache). Cachix caches can also be added using `nix run nixpkgs#cachix use <name>`.",
-                    nix_env.os.nix_config_label()
+                    nix_info.nix_env.os.nix_config_label()
                 )
             }
         };

--- a/crates/nix_health/src/check/caches.rs
+++ b/crates/nix_health/src/check/caches.rs
@@ -21,7 +21,12 @@ impl Default for Caches {
 }
 
 impl Checkable for Caches {
-    fn check(&self, nix_info: &info::NixInfo, nix_env: &env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        nix_info: &info::NixInfo,
+        nix_env: &env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check> {
         let val = &nix_info.nix_config.substituters.value;
         let missing_caches = self
             .required

--- a/crates/nix_health/src/check/direnv.rs
+++ b/crates/nix_health/src/check/direnv.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::traits::{Check, CheckResult, Checkable};
 
-use nix_rs::{env, info};
+use nix_rs::{env, flake::url::FlakeUrl, info};
 
 /// Check if direnv is installed
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -25,7 +25,12 @@ impl Default for Direnv {
 }
 
 impl Checkable for Direnv {
-    fn check(&self, _nix_info: &info::NixInfo, nix_env: &env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        _nix_info: &info::NixInfo,
+        _nix_env: &env::NixEnv,
+        flake_url: Option<FlakeUrl>,
+    ) -> Vec<Check> {
         let mut checks = vec![];
         if !self.enable {
             return checks;
@@ -37,7 +42,7 @@ impl Checkable for Direnv {
 
         if direnv_installed {
             // This check is currently only relevant if the flake is local and an `.envrc` exists.
-            match nix_env.current_local_flake() {
+            match flake_url.as_ref().and_then(|url| url.as_local_path()) {
                 None => {}
                 Some(local_path) => {
                     if local_path.join(".envrc").exists() {

--- a/crates/nix_health/src/check/direnv.rs
+++ b/crates/nix_health/src/check/direnv.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::traits::{Check, CheckResult, Checkable};
 
-use nix_rs::{env, flake::url::FlakeUrl, info};
+use nix_rs::{flake::url::FlakeUrl, info};
 
 /// Check if direnv is installed
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -25,12 +25,7 @@ impl Default for Direnv {
 }
 
 impl Checkable for Direnv {
-    fn check(
-        &self,
-        _nix_info: &info::NixInfo,
-        _nix_env: &env::NixEnv,
-        flake_url: Option<FlakeUrl>,
-    ) -> Vec<Check> {
+    fn check(&self, _nix_info: &info::NixInfo, flake_url: Option<FlakeUrl>) -> Vec<Check> {
         let mut checks = vec![];
         if !self.enable {
             return checks;

--- a/crates/nix_health/src/check/flake_enabled.rs
+++ b/crates/nix_health/src/check/flake_enabled.rs
@@ -9,7 +9,12 @@ use crate::traits::*;
 pub struct FlakeEnabled {}
 
 impl Checkable for FlakeEnabled {
-    fn check(&self, nix_info: &info::NixInfo, _nix_env: &env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        nix_info: &info::NixInfo,
+        _nix_env: &env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check> {
         let val = &nix_info.nix_config.experimental_features.value;
         let check = Check {
             title: "Flakes Enabled".to_string(),

--- a/crates/nix_health/src/check/flake_enabled.rs
+++ b/crates/nix_health/src/check/flake_enabled.rs
@@ -1,4 +1,4 @@
-use nix_rs::{env, info};
+use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
 use crate::traits::*;
@@ -12,7 +12,6 @@ impl Checkable for FlakeEnabled {
     fn check(
         &self,
         nix_info: &info::NixInfo,
-        _nix_env: &env::NixEnv,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let val = &nix_info.nix_config.experimental_features.value;

--- a/crates/nix_health/src/check/max_jobs.rs
+++ b/crates/nix_health/src/check/max_jobs.rs
@@ -9,7 +9,12 @@ use crate::traits::*;
 pub struct MaxJobs {}
 
 impl Checkable for MaxJobs {
-    fn check(&self, nix_info: &info::NixInfo, nix_env: &env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        nix_info: &info::NixInfo,
+        nix_env: &env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check> {
         let max_jobs = nix_info.nix_config.max_jobs.value;
         let check = Check {
             title: "Max Jobs".to_string(),

--- a/crates/nix_health/src/check/max_jobs.rs
+++ b/crates/nix_health/src/check/max_jobs.rs
@@ -1,4 +1,4 @@
-use nix_rs::{env, info};
+use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
 use crate::traits::*;
@@ -12,7 +12,6 @@ impl Checkable for MaxJobs {
     fn check(
         &self,
         nix_info: &info::NixInfo,
-        nix_env: &env::NixEnv,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let max_jobs = nix_info.nix_config.max_jobs.value;
@@ -26,7 +25,7 @@ impl Checkable for MaxJobs {
                     msg: "You are using only 1 core for nix builds".into(),
                     suggestion: format!(
                         "Set `max-jobs = auto` in {}",
-                        nix_env.os.nix_config_label()
+                        nix_info.nix_env.os.nix_config_label()
                     ),
                 }
             },

--- a/crates/nix_health/src/check/min_nix_version.rs
+++ b/crates/nix_health/src/check/min_nix_version.rs
@@ -1,6 +1,6 @@
 use nix_rs::version::NixVersion;
 
-use nix_rs::{env, info};
+use nix_rs::info;
 use serde::{Deserialize, Serialize};
 
 use crate::traits::*;
@@ -28,7 +28,6 @@ impl Checkable for MinNixVersion {
     fn check(
         &self,
         nix_info: &info::NixInfo,
-        _nix_env: &env::NixEnv,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let val = &nix_info.nix_version;

--- a/crates/nix_health/src/check/min_nix_version.rs
+++ b/crates/nix_health/src/check/min_nix_version.rs
@@ -25,7 +25,12 @@ impl Default for MinNixVersion {
 }
 
 impl Checkable for MinNixVersion {
-    fn check(&self, nix_info: &info::NixInfo, _nix_env: &env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        nix_info: &info::NixInfo,
+        _nix_env: &env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check> {
         let val = &nix_info.nix_version;
         let check = Check {
             title: "Minimum Nix Version".to_string(),

--- a/crates/nix_health/src/check/rosetta.rs
+++ b/crates/nix_health/src/check/rosetta.rs
@@ -1,5 +1,5 @@
 use nix_rs::{
-    env::{self, AppleEmulation, MacOSArch, OS},
+    env::{AppleEmulation, MacOSArch, OS},
     info,
 };
 use serde::{Deserialize, Serialize};
@@ -28,12 +28,11 @@ impl Default for Rosetta {
 impl Checkable for Rosetta {
     fn check(
         &self,
-        _nix_info: &info::NixInfo,
-        nix_env: &env::NixEnv,
+        nix_info: &info::NixInfo,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let mut checks = vec![];
-        if let (true, Some(emulation)) = (self.enable, get_apple_emulation(&nix_env.os)) {
+        if let (true, Some(emulation)) = (self.enable, get_apple_emulation(&nix_info.nix_env.os)) {
             let check = Check {
                 title: "Rosetta Not Active".to_string(),
                 info: format!("apple emulation = {:?}", emulation),

--- a/crates/nix_health/src/check/rosetta.rs
+++ b/crates/nix_health/src/check/rosetta.rs
@@ -26,7 +26,12 @@ impl Default for Rosetta {
 }
 
 impl Checkable for Rosetta {
-    fn check(&self, _nix_info: &info::NixInfo, nix_env: &env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        _nix_info: &info::NixInfo,
+        nix_env: &env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check> {
         let mut checks = vec![];
         if let (true, Some(emulation)) = (self.enable, get_apple_emulation(&nix_env.os)) {
             let check = Check {

--- a/crates/nix_health/src/check/system.rs
+++ b/crates/nix_health/src/check/system.rs
@@ -31,11 +31,11 @@ impl Default for System {
 impl Checkable for System {
     fn check(
         &self,
-        _nix_info: &nix_rs::info::NixInfo,
-        nix_env: &nix_rs::env::NixEnv,
+        nix_info: &nix_rs::info::NixInfo,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let mut checks = vec![];
+        let nix_env = &nix_info.nix_env;
         if self.enable {
             if let Some(min_ram) = self.min_ram {
                 checks.push(Check {

--- a/crates/nix_health/src/check/system.rs
+++ b/crates/nix_health/src/check/system.rs
@@ -33,6 +33,7 @@ impl Checkable for System {
         &self,
         _nix_info: &nix_rs::info::NixInfo,
         nix_env: &nix_rs::env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let mut checks = vec![];
         if self.enable {

--- a/crates/nix_health/src/check/trusted_users.rs
+++ b/crates/nix_health/src/check/trusted_users.rs
@@ -11,16 +11,15 @@ impl Checkable for TrustedUsers {
     fn check(
         &self,
         nix_info: &nix_rs::info::NixInfo,
-        nix_env: &nix_rs::env::NixEnv,
         _: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check> {
         let val = &nix_info.nix_config.trusted_users.value;
-        let current_user = &nix_env.current_user;
+        let current_user = &nix_info.nix_env.current_user;
         let result = if val.contains(current_user) {
             CheckResult::Green
         } else {
             let msg = format!("User '{}' not present in trusted_users", current_user);
-            let suggestion = match nix_env.os.nix_system_config_label() {
+            let suggestion = match nix_info.nix_env.os.nix_system_config_label() {
                 Some(conf_label) => format!(
                     r#"Add `nix.trustedUsers = [ "root" "{}" ];` to your {}"#,
                     current_user, conf_label,

--- a/crates/nix_health/src/check/trusted_users.rs
+++ b/crates/nix_health/src/check/trusted_users.rs
@@ -8,7 +8,12 @@ use crate::traits::*;
 pub struct TrustedUsers {}
 
 impl Checkable for TrustedUsers {
-    fn check(&self, nix_info: &nix_rs::info::NixInfo, nix_env: &nix_rs::env::NixEnv) -> Vec<Check> {
+    fn check(
+        &self,
+        nix_info: &nix_rs::info::NixInfo,
+        nix_env: &nix_rs::env::NixEnv,
+        _: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check> {
         let val = &nix_info.nix_config.trusted_users.value;
         let current_user = &nix_env.current_user;
         let result = if val.contains(current_user) {

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -67,12 +67,11 @@ impl NixHealth {
     pub fn run_checks(
         &self,
         nix_info: &nix_rs::info::NixInfo,
-        nix_env: &nix_rs::env::NixEnv,
         flake_url: Option<FlakeUrl>,
     ) -> Vec<traits::Check> {
         tracing::info!("🩺 Running health checks");
         self.into_iter()
-            .flat_map(|c| c.check(nix_info, nix_env, flake_url.clone()))
+            .flat_map(|c| c.check(nix_info, flake_url.clone()))
             .collect()
     }
 

--- a/crates/nix_health/src/lib.rs
+++ b/crates/nix_health/src/lib.rs
@@ -5,6 +5,7 @@ pub mod report;
 pub mod traits;
 
 use check::direnv::Direnv;
+use nix_rs::flake::url::FlakeUrl;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -67,10 +68,11 @@ impl NixHealth {
         &self,
         nix_info: &nix_rs::info::NixInfo,
         nix_env: &nix_rs::env::NixEnv,
+        flake_url: Option<FlakeUrl>,
     ) -> Vec<traits::Check> {
         tracing::info!("🩺 Running health checks");
         self.into_iter()
-            .flat_map(|c| c.check(nix_info, nix_env))
+            .flat_map(|c| c.check(nix_info, nix_env, flake_url.clone()))
             .collect()
     }
 

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -67,24 +67,24 @@ async fn run_checks(flake_url: Option<FlakeUrl>) -> anyhow::Result<Vec<Check>> {
     let nix_info = NixInfo::from_nix(&NixCmd::default())
         .await
         .with_context(|| "Unable to gather nix info")?;
-    let nix_env = NixEnv::detect(flake_url.clone())
+    let nix_env = NixEnv::detect()
         .await
         .with_context(|| "Unable to gather system info")?;
     let action_msg = format!(
         "🩺️ Checking the health of your Nix setup ({} on {})",
         &nix_info.nix_config.system.value, &nix_env.os
     );
-    let health: NixHealth = match flake_url {
+    let health: NixHealth = match flake_url.as_ref() {
         Some(flake_url) => {
             println!("{}, using config from flake '{}':", action_msg, flake_url);
-            NixHealth::from_flake(flake_url).await
+            NixHealth::from_flake(flake_url.clone()).await
         }
         None => {
             println!("{}:", action_msg);
             Ok(NixHealth::default())
         }
     }?;
-    let checks = health.run_checks(&nix_info, &nix_env);
+    let checks = health.run_checks(&nix_info, &nix_env, flake_url.clone());
     Ok(checks)
 }
 

--- a/crates/nix_health/src/main.rs
+++ b/crates/nix_health/src/main.rs
@@ -84,7 +84,7 @@ async fn run_checks(flake_url: Option<FlakeUrl>) -> anyhow::Result<Vec<Check>> {
             Ok(NixHealth::default())
         }
     }?;
-    let checks = health.run_checks(&nix_info, &nix_env, flake_url.clone());
+    let checks = health.run_checks(&nix_info, flake_url.clone());
     Ok(checks)
 }
 

--- a/crates/nix_health/src/traits.rs
+++ b/crates/nix_health/src/traits.rs
@@ -7,8 +7,12 @@ pub trait Checkable {
     ///
     /// NOTE: Some checks may perform impure actions (IO, etc.). Returning an
     /// empty vector indicates that the check is skipped on this environment.
-    /// TODO: This should be async!
-    fn check(&self, nix_info: &nix_rs::info::NixInfo, nix_env: &nix_rs::env::NixEnv) -> Vec<Check>;
+    fn check(
+        &self,
+        nix_info: &nix_rs::info::NixInfo,
+        nix_env: &nix_rs::env::NixEnv,
+        flake: Option<nix_rs::flake::url::FlakeUrl>,
+    ) -> Vec<Check>;
 }
 
 /// A health check

--- a/crates/nix_health/src/traits.rs
+++ b/crates/nix_health/src/traits.rs
@@ -10,7 +10,6 @@ pub trait Checkable {
     fn check(
         &self,
         nix_info: &nix_rs::info::NixInfo,
-        nix_env: &nix_rs::env::NixEnv,
         flake: Option<nix_rs::flake::url::FlakeUrl>,
     ) -> Vec<Check>;
 }

--- a/crates/nix_rs/src/env.rs
+++ b/crates/nix_rs/src/env.rs
@@ -6,15 +6,11 @@ use os_info;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::flake::url::FlakeUrl;
-
 /// The environment in which Nix operates
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NixEnv {
     /// Current user ($USER)
     pub current_user: String,
-    /// Current flake context
-    pub current_flake: Option<FlakeUrl>,
     /// Underlying OS in which Nix runs
     pub os: OS,
     /// Total disk space of the volume where /nix exists.
@@ -29,7 +25,7 @@ impl NixEnv {
     /// Determine [NixEnv] on the user's system
 
     #[instrument]
-    pub async fn detect(current_flake: Option<FlakeUrl>) -> Result<NixEnv, NixEnvError> {
+    pub async fn detect() -> Result<NixEnv, NixEnvError> {
         use sysinfo::{DiskExt, SystemExt};
         tracing::info!("Detecting Nix environment");
         let os = OS::detect().await;
@@ -42,7 +38,6 @@ impl NixEnv {
             let total_memory = to_bytesize(sys.total_memory());
             Ok(NixEnv {
                 current_user,
-                current_flake,
                 os,
                 total_disk_space,
                 total_memory,
@@ -50,13 +45,6 @@ impl NixEnv {
         })
         .await
         .unwrap()
-    }
-
-    /// Return [NixEnv::current_flake] as a local path if it is one
-    pub fn current_local_flake(&self) -> Option<&Path> {
-        self.current_flake
-            .as_ref()
-            .and_then(|url| url.as_local_path())
     }
 }
 

--- a/crates/nix_rs/src/info.rs
+++ b/crates/nix_rs/src/info.rs
@@ -1,7 +1,7 @@
 //! Information about the user's Nix installation
 use serde::{Deserialize, Serialize};
 
-use crate::{config::NixConfig, version::NixVersion};
+use crate::{config::NixConfig, env::NixEnv, version::NixVersion};
 
 /// All the information about the user's Nix installation
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -9,19 +9,28 @@ pub struct NixInfo {
     /// Nix version string
     pub nix_version: NixVersion,
     pub nix_config: NixConfig,
+    pub nix_env: NixEnv,
 }
 
 impl NixInfo {
     /// Determine [NixInfo] on the user's system
-
-    pub async fn from_nix(
-        nix_cmd: &crate::command::NixCmd,
-    ) -> Result<NixInfo, crate::command::NixCmdError> {
+    pub async fn from_nix(nix_cmd: &crate::command::NixCmd) -> Result<NixInfo, NixInfoError> {
         let nix_version = NixVersion::from_nix(nix_cmd).await?;
         let nix_config = NixConfig::from_nix(nix_cmd).await?;
+        let nix_env = NixEnv::detect().await?;
         Ok(NixInfo {
             nix_version,
             nix_config,
+            nix_env,
         })
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum NixInfoError {
+    #[error("Nix command error: {0}")]
+    NixCmdError(#[from] crate::command::NixCmdError),
+
+    #[error("Nix environment error: {0}")]
+    NixEnvError(#[from] crate::env::NixEnvError),
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -103,7 +103,7 @@ impl AppState {
         tracing::debug!("Updating nix env ...");
         Datum::refresh_with(self.nix_env, async {
             let nix_env = tokio::spawn(async move {
-                nix_rs::env::NixEnv::detect(None)
+                nix_rs::env::NixEnv::detect()
                     .await
                     .map_err(|e| e.to_string().into())
             })
@@ -180,7 +180,7 @@ impl AppState {
                                     .as_ref()
                                     .map_err(|e| Into::<SystemError>::into(e.to_string()))?;
                                 let health_checks =
-                                    NixHealth::default().run_checks(nix_info, nix_env);
+                                    NixHealth::default().run_checks(nix_info, nix_env, None);
                                 Ok(health_checks)
                             };
                         get_nix_health()

--- a/src/app/state/datum.rs
+++ b/src/app/state/datum.rs
@@ -37,30 +37,6 @@ impl<T> Datum<T> {
         }
     }
 
-    pub fn pure(value: T) -> Datum<T> {
-        Datum::Available {
-            value,
-            refreshing: false,
-        }
-    }
-
-    /// Chain [Datum]'s together monadically
-    ///
-    /// The resulting Datum is considered "available" only if both the datums
-    /// are available and the left datum is not refreshing.
-    pub fn and_then<U, F>(&self, f: F) -> Datum<U>
-    where
-        F: FnOnce(&T) -> Datum<U>,
-    {
-        match self {
-            Datum::Available {
-                value: x,
-                refreshing: false,
-            } => f(x),
-            _ => Datum::Loading,
-        }
-    }
-
     /// Set the datum value
     ///
     /// Use [refresh_with] if the value is produced by a long-running task.


### PR DESCRIPTION
Keeping them together makes it simpler to deal with them in the UI