### PR TITLE
Task aware `Datum`s

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -107,12 +107,9 @@ impl AppState {
             use_future(cx, (&flake_url, &idx), |(flake_url, idx)| async move {
                 tracing::info!("Updating flake [{}] {} ...", flake_url, idx);
                 Datum::refresh_with(self.flake, async move {
-                    tokio::spawn(async move {
-                        Flake::from_nix(&nix_rs::command::NixCmd::default(), flake_url.clone())
-                            .await
-                    })
+                    Flake::from_nix(&nix_rs::command::NixCmd::default(), flake_url.clone()).await
                 })
-                .await;
+                .await
             });
         }
 
@@ -126,10 +123,8 @@ impl AppState {
                         .map(|v| v.clone())
                 }) {
                     Datum::refresh_with(self.health_checks, async move {
-                        tokio::spawn(async move {
-                            let health_checks = NixHealth::default().run_checks(&nix_info?, None);
-                            Ok(health_checks)
-                        })
+                        let health_checks = NixHealth::default().run_checks(&nix_info?, None);
+                        Ok(health_checks)
                     })
                     .await;
                 }
@@ -144,15 +139,11 @@ impl AppState {
             use_future(cx, (&idx,), |(idx,)| async move {
                 tracing::info!("Updating nix info [{}] ...", idx);
                 Datum::refresh_with(self.nix_info, async {
-                    // NOTE: Without tokio::spawn, this will run in main desktop thread,
-                    // and will hang at some point.
-                    tokio::spawn(async move {
-                        nix_rs::info::NixInfo::from_nix(&nix_rs::command::NixCmd::default())
-                            .await
-                            .map_err(|e| SystemError {
-                                message: format!("Error getting nix info: {:?}", e),
-                            })
-                    })
+                    nix_rs::info::NixInfo::from_nix(&nix_rs::command::NixCmd::default())
+                        .await
+                        .map_err(|e| SystemError {
+                            message: format!("Error getting nix info: {:?}", e),
+                        })
                 })
                 .await;
             });

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -106,44 +106,30 @@ impl AppState {
             let idx = *refresh_action.read();
             use_future(cx, (&flake_url, &idx), |(flake_url, idx)| async move {
                 tracing::info!("Updating flake [{}] {} ...", flake_url, idx);
-                // Abort previously running task, otherwise Datum refresh will panic
-                // TODO: Refactor this by changing the [Datum] type to be a
-                // struct (not enum) containing the
-                // `CopyValue<Option<JoinHandle<T>>>`
-                self.flake_task_abort.with_mut(|abort_handle| {
-                    if let Some(abort_handle) = abort_handle.take() {
-                        abort_handle.abort();
-                    }
-                });
                 Datum::refresh_with(self.flake, async move {
-                    let join_handle = tokio::spawn(async move {
+                    tokio::spawn(async move {
                         Flake::from_nix(&nix_rs::command::NixCmd::default(), flake_url.clone())
                             .await
-                    });
-                    *self.flake_task_abort.write() = Some(join_handle.abort_handle());
-                    let v = join_handle.await.unwrap();
-                    *self.flake_task_abort.write() = None;
-                    v
+                    })
                 })
                 .await;
             });
         }
 
-        // Build `state.health_checks` when nix_info or nix_env changes
+        // Build `state.health_checks` when nix_info changes
         {
             let nix_info = self.nix_info.read().clone();
-            use_future(cx, (&nix_info,), |(nix_info,)| async move {
-                if let Some(nix_info) = nix_info.current_value() {
-                    Datum::refresh_with(self.health_checks, async {
-                        let get_nix_health =
-                            move || -> Result<Vec<nix_health::traits::Check>, SystemError> {
-                                let nix_info = nix_info
-                                    .as_ref()
-                                    .map_err(|e| Into::<SystemError>::into(e.to_string()))?;
-                                let health_checks = NixHealth::default().run_checks(nix_info, None);
-                                Ok(health_checks)
-                            };
-                        get_nix_health()
+            use_future(cx, (&nix_info,), |(nix_info1,)| async move {
+                if let Some(nix_info) = nix_info1.current_value().map(|x| {
+                    x.as_ref()
+                        .map_err(|e| Into::<SystemError>::into(e.to_string()))
+                        .map(|v| v.clone())
+                }) {
+                    Datum::refresh_with(self.health_checks, async move {
+                        tokio::spawn(async move {
+                            let health_checks = NixHealth::default().run_checks(&nix_info?, None);
+                            Ok(health_checks)
+                        })
                     })
                     .await;
                 }
@@ -160,17 +146,13 @@ impl AppState {
                 Datum::refresh_with(self.nix_info, async {
                     // NOTE: Without tokio::spawn, this will run in main desktop thread,
                     // and will hang at some point.
-                    let nix_info = tokio::spawn(async move {
+                    tokio::spawn(async move {
                         nix_rs::info::NixInfo::from_nix(&nix_rs::command::NixCmd::default())
                             .await
                             .map_err(|e| SystemError {
                                 message: format!("Error getting nix info: {:?}", e),
                             })
                     })
-                    .await
-                    .unwrap();
-                    tracing::debug!("Got nix info, about to mut");
-                    nix_info
                 })
                 .await;
             });


### PR DESCRIPTION
The `Datum` type now keeps track of the loader/refresh tokio task (its `AbortHandle` specifically), so that we can cancel a previously-running refresh before doing a new one.

This refactors a change made in the #93 PR (which which change, the app will panic if the user tries to load two flakes in quick succession).