### PR TITLE
Cache retrieved flakes on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2290,7 @@ name = "nix-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assoc",
  "cfg-if",
  "clap",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "dioxus-std"
 version = "0.4.0"
-source = "git+https://github.com/ealmloff/dioxus-std.git?branch=storage#7a99a3e0f21696c0fbdcd76cbfc34898d616768d"
+source = "git+https://github.com/ealmloff/dioxus-std.git?branch=storage#9d79bb9a89a46668cd143732ea623fb024e4be5e"
 dependencies = [
  "cfg-if",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,12 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
-name = "assoc"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,7 +2284,6 @@ name = "nix-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assoc",
  "cfg-if",
  "clap",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,3 @@ dioxus-signals = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "6478
 # https://github.com/DioxusLabs/dioxus-std/pull/17
 dioxus-std = { git = "https://github.com/ealmloff/dioxus-std.git", branch="storage", features = ["storage"] }
 fermi = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "c7963a03440d5a050bf229f91665d60a0d108a8a" }
-assoc = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,4 @@ dioxus-signals = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "6478
 # https://github.com/DioxusLabs/dioxus-std/pull/17
 dioxus-std = { git = "https://github.com/ealmloff/dioxus-std.git", branch="storage", features = ["storage"] }
 fermi = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "c7963a03440d5a050bf229f91665d60a0d108a8a" }
+assoc = "0.1.3"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -147,16 +147,16 @@ fn Dashboard(cx: Scope) -> Element {
             p { "TODO: search input" }
             h2 { class: "text-2xl", "Or, try one of these:" }
             div { class: "flex flex-col",
-                for flake in state.recent_flakes.read().clone() {
+                for flake_url in state.recent_flakes() {
                     a {
                         onclick: move |_| {
                             let state = AppState::use_state(cx);
                             let nav = use_navigator(cx);
-                            state.set_flake_url(flake.clone());
+                            state.set_flake_url(flake_url.clone());
                             nav.replace(Route::Flake {});
                         },
                         class: "cursor-pointer text-primary-600 underline hover:no-underline",
-                        "{flake.clone()}"
+                        "{flake_url.clone()}"
                     }
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -147,7 +147,7 @@ fn Dashboard(cx: Scope) -> Element {
             p { "TODO: search input" }
             h2 { class: "text-2xl", "Or, try one of these:" }
             div { class: "flex flex-col",
-                for flake_url in state.recent_flakes() {
+                for flake_url in state.flake_cache.read().recent_flakes() {
                     a {
                         onclick: move |_| {
                             let state = AppState::use_state(cx);

--- a/src/app/state/db.rs
+++ b/src/app/state/db.rs
@@ -1,0 +1,61 @@
+//! A database of [Flake] intended to be cached in dioxus [Signal] and persisted to disk.
+//!
+//! This is purposefully dumb right now, but we might revisit this in future based on actual performance.
+
+use dioxus::prelude::Scope;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, time::SystemTime};
+
+use dioxus_signals::Signal;
+use dioxus_std::storage::new_storage;
+use dioxus_std::storage::LocalStorage;
+
+use crate::app::state::FlakeUrl;
+use nix_rs::flake::Flake;
+
+/// A database of [Flake] intended to be cached in dioxus [Signal] and persisted to disk.
+///
+/// Contains the "last fetched" time and the [Flake] itself.
+#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FlakeCache(HashMap<FlakeUrl, Option<(SystemTime, Flake)>>);
+
+impl FlakeCache {
+    /// Create a new [Signal] for [FlakeCache] from [LocalStorage].
+    pub fn new_signal(cx: Scope) -> Signal<FlakeCache> {
+        new_storage::<LocalStorage, _>(cx, "flake_cache".to_string(), || {
+            tracing::warn!("📦 No flake cache found");
+            let init = FlakeUrl::suggestions()
+                .into_iter()
+                .map(|url| (url, None))
+                .collect();
+            FlakeCache(init)
+        })
+    }
+
+    /// Look up a [Flake] by [FlakeUrl] in the cache.
+    pub fn get(&self, k: &FlakeUrl) -> Option<Flake> {
+        let (t, flake) = self.0.get(k).and_then(|v| v.as_ref().cloned())?;
+        tracing::info!("Cache hit for {} (updated: {:?})", k, t);
+        Some(flake)
+    }
+
+    /// Update the cache with a new [Flake].
+    pub fn update(&mut self, k: FlakeUrl, flake: Flake) {
+        tracing::info!("Caching flake [{}]", &k);
+        self.0.insert(k, Some((SystemTime::now(), flake)));
+    }
+
+    /// Recently updated flakes, along with any unavailable flakes in cache.
+    pub fn recent_flakes(&self) -> Vec<FlakeUrl> {
+        let mut pairs: Vec<_> = self
+            .0
+            .iter()
+            .filter_map(|(k, v)| v.as_ref().map(|(t, _)| (k, t)))
+            .collect();
+
+        // Sort by the timestamp in descending order.
+        pairs.sort_unstable_by(|a, b| b.1.cmp(a.1));
+
+        pairs.into_iter().map(|(k, _)| k.clone()).collect()
+    }
+}

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -43,7 +43,10 @@ pub struct AppState {
 impl AppState {
     fn new(cx: Scope) -> Self {
         tracing::info!("🔨 Creating new AppState");
-        let flake_cache = new_storage::<LocalStorage, _>(cx, "flake_cache".to_string(), Vec::new);
+        let flake_cache = new_storage::<LocalStorage, _>(cx, "flake_cache".to_string(), || {
+            tracing::warn!("📦 No flake cache found");
+            Vec::new()
+        });
         AppState {
             flake_cache,
             ..AppState::default()

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -43,6 +43,7 @@ pub struct AppState {
 impl AppState {
     fn new(cx: Scope) -> Self {
         tracing::info!("🔨 Creating new AppState");
+        // TODO: Should we use new_synced_storage, instead? To allow multiple app windows?
         let flake_cache = new_storage::<LocalStorage, _>(cx, "flake_cache".to_string(), || {
             tracing::warn!("📦 No flake cache found");
             Vec::new()

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -100,16 +100,16 @@ impl AppState {
                 let flake_url = self.flake_url.read().clone();
                 if let Some(flake_url) = flake_url {
                     let flake_url_2 = flake_url.clone();
-                    tracing::info!("Updating flake [{}] refresh={} ...", flake_url, refresh);
-                    Datum::refresh_with(self.flake, async move {
+                    tracing::info!("Updating flake [{}] refresh={} ...", &flake_url, refresh);
+                    let res = Datum::refresh_with(self.flake, async move {
                         Flake::from_nix(&nix_rs::command::NixCmd::default(), flake_url_2)
                             .await
                             .map_err(|e| Into::<SystemError>::into(e.to_string()))
                     })
                     .await;
-                    if let Some(Ok(flake)) = self.flake.read().current_value() {
+                    if let Some(Ok(flake)) = res {
                         self.flake_cache.with_mut(|cache| {
-                            cache.update(flake_url, flake.clone());
+                            cache.update(flake_url, flake);
                         });
                     }
                 }


### PR DESCRIPTION
Flakes are fetched once and cached on disk, so as to persist across app restarts. To refetch, the user can hit the 'refresh' button.

- [x] dioxus-std storage deserialization issues https://github.com/DioxusLabs/dioxus-std/pull/17#pullrequestreview-1719137114
- [ ] trim cache size?
- [ ] refactor build_network logic