### PR TITLE
Allow building on Intel mac and linux system with nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
           packages = with pkgs; [
             just
             nixci
+            pkg-config
             # For when we start using Tauri
             cargo-tauri
             trunk

--- a/rust.nix
+++ b/rust.nix
@@ -16,6 +16,7 @@
         ]) ++ lib.optionals pkgs.stdenv.isDarwin (
         with pkgs.darwin.apple_sdk.frameworks; [
           IOKit
+          pkgs.darwin.apple_sdk_11_0.frameworks.IOKit
           Carbon
           WebKit
           Security


### PR DESCRIPTION
Intel builds were failing with error
```
Undefined symbols for architecture x86_64:
       >             "_kCFURLVolumeAvailableCapacityForImportantUsageKey", referenced from:
```
due to missing `IOKit` dependency for rust

and 
nixos build were failing due to missing package `pkg-config`